### PR TITLE
Create docker-compose_rpi-pihole-bind9.yaml

### DIFF
--- a/docker-compose_rpi-pihole-bind9.yaml
+++ b/docker-compose_rpi-pihole-bind9.yaml
@@ -1,0 +1,40 @@
+version: '3.7'
+
+services:
+  pihole:
+      restart: unless-stopped
+      container_name: pihole
+      image: pihole/pihole:latest
+      dns: 127.0.0.1
+      hostname: pihole
+      volumes:
+        - /var/pihole:/etc/pihole
+      environment:
+        - TZ= "Europe/Berlin"
+        - ServerIP=192.168.0.10
+        - WEBPASSWORD= # Setze hier ein starkes Passwort
+        - DNS1=172.18.0.x:53 #interne IP Docker-Netz -> Bind Server
+        - DNS2=
+        - VIRTUAL_HOST=pihole
+      cap_add:
+        - NET_ADMIN
+      ports:
+        - "53:53/tcp"
+        - "53:53/udp"
+        - "67:67/udp"
+        - "80:80/tcp"
+        - "443:443/tcp"
+
+  bind:
+    restart: unless-stopped
+    container_name: rpi-bind9-svr
+    image: sameersbn/bind:latest
+    environment:
+      - ROOT_PASSWORD=# Setze hier ein starkes Passwort
+     # - WEBMIN_ENABLED=false # GUI abschalten (Sicherheit!) nachdem Bind konfiguriert ist.
+    ports:
+     - 192.168.0.10:10000:10000/tcp
+     - 192.168.0.10:10053:53/tcp # Port auf 10053 gemappt, da 53 schon von Pihole verwendet wird.
+     - 192.168.0.10:10053:53/udp
+    volumes:
+      - /srv/docker/bind:/data


### PR DESCRIPTION
Docker-Compose Datei für Pihole (https://hub.docker.com/r/pihole/pihole/) auf dem Raspberry Pi.

Zusätzlich ein Bind-Nameserver für das lokale interne Netz.
Verwendung:
Dann kann man eigene Rechner, virtuelle Maschinen usw. über eine eigene Domäne im Heimnetz betreiben. Somit lassen sich dann auch eigene SSL Zertifikate für Webserver u.ä. auf den Domänennamen ausstellen.

Für den Bind Server als Dockerimage verwende ich (sameersbn/docker-bind).

https://github.com/sameersbn/docker-bind

Anleitung:

http://www.damagehead.com/blog/2015/04/28/deploying-a-dns-server-using-docker/

Das Docker Image für den Raspberry PI muss aus den Quellen ebenfalls neu erstellt/compiliert werden.

docker build -t sameersbn/bind github.com/sameersbn/docker-bind